### PR TITLE
chore: bump minor (not patch) for feat commits pre-1.0

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,7 +4,6 @@
   "include-component-in-tag": false,
   "include-v-in-tag": true,
   "bump-minor-pre-major": true,
-  "bump-patch-for-minor-pre-major": true,
   "packages": {
     ".": {
       "component": "form-forge",


### PR DESCRIPTION
Removes `bump-patch-for-minor-pre-major` from the release-please config so that `feat` commits bump the **minor** version while the project is still on `0.x`, instead of the patch version.

### Before (current behavior)
| Commit | Bump |
|---|---|
| `fix:` | patch |
| `feat:` | patch |
| `feat!:` / breaking | minor |

### After
| Commit | Bump |
|---|---|
| `fix:` | patch |
| `feat:` | **minor** |
| `feat!:` / breaking | minor |

`bump-minor-pre-major: true` is kept, so breaking changes still bump minor (not major) until we hit 1.0.0.

Context: PR #113 produced a `0.1.1` release-please bump despite containing `feat` commits, which was unexpected. This makes `feat` move the minor as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)